### PR TITLE
Add URI patterns for Amazon Prime Video & Tatacliq

### DIFF
--- a/affiliate.txt
+++ b/affiliate.txt
@@ -22,6 +22,9 @@
 ||amazon.fr/*?tag=
 ||amazon.fr/*&tag=
 
+!Amazon Prime Video
+||primevideo.com/*?ref=
+
 !Apple
 ||itunes.apple.com/*?at=
 ||itunes.apple.com/*&at=
@@ -155,6 +158,10 @@
 ||apessay.com/*?rid=
 ||apessay.com/*&rid=
 
+!Tatacliq
+||tatacliq.com/*?cid=af:
+
 !Zaful
 ||zaful.com/*?lkid=
 ||zaful.com/*&lkid=
+


### PR DESCRIPTION
Hi, I came across your tweet about fighting against affiliate ads on the internet disguised as native content, and I thought I'd contribute what I can. I've added a couple of affiliate links to your file for test. I'm a newbie to GitHub, so forgive me if I did it wrong in any way.

My changes include the affiliate link URI patterns for:

- Amazon Prime Video
- Tatacliq

I've put them in alphabetical order just like you have. Thanks.