### PR TITLE
Add URI patterns for Audible

### DIFF
--- a/affiliate_markting_links.txt
+++ b/affiliate_markting_links.txt
@@ -6,6 +6,9 @@
 ||performance.affiliaxe.com/*?aff_id=
 ||performance.affiliaxe.com/*&aff_id=
 
+!airbnb
+||airbnb.com/c/
+
 !AliExpress
 ||s.aliexpress.com/*?af=
 ||s.aliexpress.com/*&af=
@@ -163,6 +166,14 @@
 !RewardStyle
 ||rstyle.me^
 
+!Robinhood
+||referral.robinhood.com
+||share.robinhood.com
+
+!SeatGeek
+||seatgeek.com/promos?aid=
+||seatgeek.com/promos*&aid=
+
 !ShopStyle
 ||shopstyle.it^
 
@@ -175,6 +186,12 @@
 ||apessay.com/*?rid=
 ||apessay.com/*&rid=
 
+!SquareSpace
+||squarespace.com/*?channel=youtube
+||squarespace.com/*&channel=youtube
+||squarespace.com/*?subchannel=
+||squarespace.com/*&subchannel=
+
 !TataCLiQ
 ||tatacliq.com/*?cid=af:
 ||tatacliq.com/*&cid=af:
@@ -182,6 +199,10 @@
 !Thermoworks
 ||thermoworks.com/*?tw=
 ||thermoworks.com/*&tw=
+
+!Winc
+||winc.com/try/*?caid=
+||winc.com/try/*&caid=
 
 !Zaful
 ||zaful.com/*?lkid=

--- a/affiliate_markting_links.txt
+++ b/affiliate_markting_links.txt
@@ -32,6 +32,9 @@
 ||apple.com/*?afid=
 ||apple.com/*&afid=
 
+!Audible
+||audible.com/ep/
+
 !Audiobooks
 ||affiliates.audiobooks.com/*?a_aid=*&a_bid=
 ||affiliates.audiobooks.com/*?a_bid=*&a_aid=


### PR DESCRIPTION
@aruneshmathur I saw that audible links (like http://audible.com/VERITASIUM and its redirects) are not currently supported so I added this to the pattern matching. 

The pattern includes:
* https://www.audible.com/ep/youtube?*
* https://www.audible.com/ep/podcast?*

I am not sure about other ones, but to be safe I just included all of them. If you would prefer to just add each individual one and investigate other options, we could also do that.